### PR TITLE
type completion in VSCode

### DIFF
--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -37,9 +37,9 @@ npm i --save-dev paypax
 or
 yarn add -D paypax
 or
-pnpm i -save-dev paypax
+pnpm add --save-dev paypax
 or
-bun i -D paypax
+bun add -D paypax
 ```
 
 - Deno

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "node": ">=18.0.0"
   },
   "main": "dist/index.js",
+  "types": "dist/types",
   "type": "module"
 }


### PR DESCRIPTION
# 何を変更したのか

VSCode+Node.js+TypeScriptで使用する際に、型補完が効かない問題を修正しました。(denoだと元々問題なく効きます)

具体的には、`package.json`に`types`の値を追加しました。

Before
<img height="300px" src="https://github.com/EdamAme-x/paypax/assets/120777733/de7b6e2f-ba9f-4ffa-a84f-5ee6b989728c"></img>

After
![スクリーンショット 2024-01-20 114324](https://github.com/EdamAme-x/paypax/assets/120777733/10663994-b8a4-4c79-8abf-cbc855887d31)

余談ですが、ビルドしたら #13 の修正が`deno_dist`の方に反映されてなかったみたいで、ついてきましたので一緒にどうぞ

## Tasks

<!-----
Pull Request を出した後に達成することをオススメします。
------>
### 必須
- [x] pnpm build:all

### 出来たら
- [ ] add Test
